### PR TITLE
pip installation order issue

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -46,6 +46,8 @@ to resolve the following dependencies before the pip installer is run:
     * scikit-image >=0.21.0
     * shapely
 
+    NOTE: the gdal library must be installed before numpy, otherwise do a [re-installation](https://gis.stackexchange.com/a/465888/140483) in order to respect the build isolation
+
 Then, the pip installer can be run by:
 
    .. code-block:: bash


### PR DESCRIPTION
adding note to installation using pip, resolve an issue about build isolation.

If during pip(>v23.0)  installation process in a custom virtual environment GDAL is installed after NUMPY the module _gdal_array was not found.

This pull request simple add a warning-NOTE  to installation doc