### PR TITLE
Tiepoint sample random state

### DIFF
--- a/arosics/CoReg_local.py
+++ b/arosics/CoReg_local.py
@@ -73,6 +73,7 @@ class COREG_LOCAL(object):
                  max_iter: int = 5,
                  max_shift: int = 5,
                  tieP_filter_level: int = 3,
+                 tieP_random_state: Optional[int] = 0,
                  min_reliability: float = 60,
                  rs_max_outlier: float = 10,
                  rs_tolerance: float = 2.5,
@@ -98,7 +99,7 @@ class COREG_LOCAL(object):
                  progress: bool = True,
                  v: bool = False,
                  q: bool = False,
-                 ignore_errors: bool = True
+                 ignore_errors: bool = True,
                  ) -> None:
         """
         Get an instance of COREG_LOCAL.
@@ -161,6 +162,9 @@ class COREG_LOCAL(object):
                        - filters all tie points out where shift correction does not increase image similarity within
                          matching window (measured by mean structural similarity index)
             - Level 3: RANSAC outlier detection
+
+        :param tieP_random_state:
+            Tiepoint sampling random state (an integer corresponds to a fixed/pseudo-random state, None randomizes the result)
 
         :param min_reliability:
             Tie point filtering: minimum reliability threshold, below which tie points are marked as false-positives
@@ -286,6 +290,7 @@ class COREG_LOCAL(object):
         self.max_shift = max_shift
         self.max_iter = max_iter
         self.tieP_filter_level = tieP_filter_level
+        self.tieP_random_state = tieP_random_state
         self.min_reliability = min_reliability
         self.rs_max_outlier = rs_max_outlier
         self.rs_tolerance = rs_tolerance
@@ -446,6 +451,7 @@ class COREG_LOCAL(object):
                            outFillVal=self.outFillVal,
                            resamp_alg_calc=self.rspAlg_calc,
                            tieP_filter_level=self.tieP_filter_level,
+                           tieP_random_state=self.tieP_random_state,
                            outlDetect_settings=dict(
                                min_reliability=self.min_reliability,
                                rs_max_outlier=self.rs_max_outlier,

--- a/arosics/CoReg_local.py
+++ b/arosics/CoReg_local.py
@@ -99,7 +99,7 @@ class COREG_LOCAL(object):
                  progress: bool = True,
                  v: bool = False,
                  q: bool = False,
-                 ignore_errors: bool = True,
+                 ignore_errors: bool = True
                  ) -> None:
         """
         Get an instance of COREG_LOCAL.

--- a/arosics/Tie_Point_Grid.py
+++ b/arosics/Tie_Point_Grid.py
@@ -71,6 +71,7 @@ class Tie_Point_Grid(object):
                  outFillVal: int = -9999,
                  resamp_alg_calc: str = 'cubic',
                  tieP_filter_level: int = 3,
+                 tieP_random_state: int = 0,
                  outlDetect_settings: dict = None,
                  dir_out: str = None,
                  CPUs: int = None,
@@ -112,6 +113,9 @@ class Tie_Point_Grid(object):
                          matching window (measured by mean structural similarity index)
             - Level 3: RANSAC outlier detection
 
+        :param tieP_random_state:
+            Tiepoint sampling random state (an integer corresponds to a fixed/pseudo-random state, None randomizes the result)
+
         :param outlDetect_settings:
             a dictionary with the settings to be passed to arosics.TiePointGrid.Tie_Point_Refiner.
             Available keys: min_reliability, rs_max_outlier, rs_tolerance, rs_max_iter, rs_exclude_previous_outliers,
@@ -142,6 +146,7 @@ class Tie_Point_Grid(object):
         self.outFillVal = outFillVal
         self.rspAlg_calc = resamp_alg_calc
         self.tieP_filter_level = tieP_filter_level
+        self.tieP_random_state = tieP_random_state
         self.outlDetect_settings = outlDetect_settings or dict()
         self.dir_out = dir_out
         self.CPUs = CPUs
@@ -312,7 +317,7 @@ class Tie_Point_Grid(object):
 
         # choose a random subset of points if a maximum number has been given
         if self.max_points and len(GDF) > self.max_points:
-            GDF = GDF.sample(self.max_points).copy()
+            GDF = GDF.sample(self.max_points, random_state = self.tieP_random_state).copy()
 
         # equalize pixel grids in order to save warping time
         if len(GDF) > 100:
@@ -782,7 +787,7 @@ class Tie_Point_Grid(object):
                 return []
 
             if avail_TP > 7000:
-                GDF = GDF.sample(7000)
+                GDF = GDF.sample(7000, random_state = self.tieP_random_state)
                 warn('By far not more than 7000 tie points can be used for warping within a limited '
                      'computation time (due to a GDAL bottleneck). Thus these 7000 points are randomly chosen '
                      'out of the %s available tie points.' % avail_TP)

--- a/tests/test_tie_point_grid.py
+++ b/tests/test_tie_point_grid.py
@@ -53,6 +53,7 @@ class Test_Tie_Point_Grid(unittest.TestCase):
                                  outFillVal=CRL.outFillVal,
                                  resamp_alg_calc=CRL.rspAlg_calc,
                                  tieP_filter_level=CRL.tieP_filter_level,
+                                 tieP_random_state=CRL.tieP_random_state,
                                  outlDetect_settings=dict(
                                      min_reliability=CRL.min_reliability,
                                      rs_max_outlier=CRL.rs_max_outlier,
@@ -176,6 +177,23 @@ class Test_Tie_Point_Grid(unittest.TestCase):
 
             assert isinstance(arr_interp, np.ndarray)
 
+    def test_random_state(self):
+
+        self.TPG.tieP_random_state = None
+
+        pts = []
+        for _ in range(2):
+            pts.append(self.TPG.get_CoRegPoints_table()['POINT_ID'])
+
+        assert not np.array_equal(pts[0], pts[1]), "Samples should not be identical when random state is None"
+
+        self.TPG.tieP_random_state = 0
+
+        pts = []
+        for _ in range(2):
+            pts.append(self.TPG.get_CoRegPoints_table()['POINT_ID'])
+
+        assert np.array_equal(pts[0], pts[1]), "Samples should be identical when random state is fixed"
 
 if __name__ == '__main__':
     pytest.main()


### PR DESCRIPTION
This PR introduces a random state variable, `tieP_random_state`, for tiepoint sampling, ensuring repeatability when the `max_points` argument is used or when the number of tiepoints exceeds 7000. It follows the same format as the RANSAC random state: `0` by default, and `None` to randomize the result.

Added test to check for repeatability of results when the random state variable is specified:

`python -m unittest tests.test_tie_point_grid.Test_Tie_Point_Grid.test_random_state`